### PR TITLE
feat/transform params and response keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A gem to standardize json responses in Rails applications, highly inspired on [R
 - [Usage](#usage)
   - [Respondering json](#respondering-json)
   - [Success and failure actions](#success-and-failure-actions)
+  - [Transform keys](#transform-keys)
 - [Overriding response](#overriding-response)
 - [Pagination](#pagination)
 - [Contributing](#contributing)
@@ -140,6 +141,20 @@ witht `status_code` 422
 The `message` key is different based on actions on informed model: create, update, and destroy
 
 You can respond any type of data, but ActiveRecord/ActiveModel::Model and ActiveRecord::Relation has a special treatment as shown above
+
+### Transform keys
+
+It is possible to transform the keys of request and response. By default, will transform to `snake_case`, but the possible values are `snake_case`, `camel_lower` and `camel_case`
+
+To change the transform operation, simply adds a initializer on initilizations folder with content:
+```ruby
+MiniApi::Config.configure do |config|
+  config.transform_params_keys_to = :snake_case
+  config.transform_response_keys_to = :camel_lower
+end
+```
+The option `transform_params_keys_to` will transform request params.
+The option `transform_response_keys_to` will transform responses.
 
 ## Overriding response
 

--- a/lib/mini_api.rb
+++ b/lib/mini_api.rb
@@ -2,6 +2,7 @@
 
 require 'mini_api/railtie'
 require 'mini_api/responder'
+require 'mini_api/case_transform'
 
 # Entrypoint module
 module MiniApi

--- a/lib/mini_api.rb
+++ b/lib/mini_api.rb
@@ -6,6 +6,18 @@ require 'mini_api/case_transform'
 
 # Entrypoint module
 module MiniApi
+  extend ActiveSupport::Concern
+
+  included do
+    include CaseTransform
+
+    before_action :transform_params
+
+    def transform_params
+      self.params = ActionController::Parameters.new(CaseTransform.transform(request.parameters))
+    end
+  end
+
   def render_json(resource, options = {})
     responder = Responder.new(self, resource, options)
 

--- a/lib/mini_api.rb
+++ b/lib/mini_api.rb
@@ -14,7 +14,8 @@ module MiniApi
     before_action :transform_params
 
     def transform_params
-      self.params = ActionController::Parameters.new(CaseTransform.transform(request.parameters))
+      self.params =
+        ActionController::Parameters.new(CaseTransform.request_params_keys(request.parameters))
     end
   end
 

--- a/lib/mini_api/case_transform.rb
+++ b/lib/mini_api/case_transform.rb
@@ -7,11 +7,9 @@ module MiniApi
   module CaseTransform
     module_function
 
-    def transform(object = {})
-      transform_keys_to = MiniApi::Config.transform_keys_to
-
+    def transform(object, transform_to = :snake_case)
       object.deep_transform_keys do |key|
-        case transform_keys_to
+        case transform_to
         when :camel_case
           key.to_s.camelize
         when :camel_lower
@@ -19,9 +17,17 @@ module MiniApi
         when :snake_case
           key.to_s.underscore
         else
-          raise CaseTransformOptionInvalid, "option #{transform_keys_to} is not supported."
+          raise CaseTransformOptionInvalid, "option #{transform_to} is not supported."
         end
       end
+    end
+
+    def request_params_keys(params)
+      transform(params, Config.transform_params_keys_to)
+    end
+
+    def response_keys(response)
+      transform(response, Config.transform_response_keys_to)
     end
   end
 end

--- a/lib/mini_api/case_transform.rb
+++ b/lib/mini_api/case_transform.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'mini_api/config'
+require 'mini_api/exceptions/case_transform_option_invalid'
+
+module MiniApi
+  module CaseTransform
+    module_function
+
+    def transform(object = {})
+      transform_keys_to = MiniApi::Config.transform_keys_to
+
+      object.deep_transform_keys do |key|
+        case transform_keys_to
+        when :camel_case
+          key.to_s.camelize
+        when :camel_lower
+          key.to_s.camelize(:lower)
+        when :snake_case
+          key.to_s.underscore
+        else
+          raise CaseTransformOptionInvalid, "option #{transform_keys_to} is not supported."
+        end
+      end
+    end
+  end
+end

--- a/lib/mini_api/config.rb
+++ b/lib/mini_api/config.rb
@@ -5,6 +5,7 @@ module MiniApi
     include ActiveSupport::Configurable
 
     # permitted values are: [:camel_case, :camel_lower, snake_case]
-    config_accessor :transform_keys_to, instance_accessor: false, default: :snake_case
+    config_accessor :transform_params_keys_to, instance_accessor: false, default: :snake_case
+    config_accessor :transform_response_keys_to, instance_accessor: false, default: :snake_case
   end
 end

--- a/lib/mini_api/config.rb
+++ b/lib/mini_api/config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module MiniApi
+  class Config
+    include ActiveSupport::Configurable
+
+    # permitted values are: [:camel_case, :camel_lower, snake_case]
+    config_accessor :transform_keys_to, instance_accessor: false, default: :snake_case
+  end
+end

--- a/lib/mini_api/default_responder.rb
+++ b/lib/mini_api/default_responder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'mini_api/case_transform'
+
 module MiniApi
   class DefaultResponder
     def initialize(controller, resource, options = {})
@@ -11,14 +13,32 @@ module MiniApi
     def respond
       success = @options[:success] != false
 
+      data = transform_keys
+
       @controller.render(
         json: {
           success: success,
-          data: @resource,
+          data: data,
           message: @options[:message] || nil
         },
         status: @options[:status] || :ok
       )
+    end
+
+    private
+
+    def transform_keys
+      return CaseTransform.response_keys(@resource) if @resource.is_a?(Hash)
+
+      return @resource unless @resource.is_a?(Array)
+
+      @resource.map do |item|
+        if item.is_a?(Hash)
+          CaseTransform.response_keys(item)
+        else
+          item
+        end
+      end
     end
   end
 end

--- a/lib/mini_api/exceptions/case_transform_option_invalid.rb
+++ b/lib/mini_api/exceptions/case_transform_option_invalid.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module MiniApi
+  class CaseTransformOptionInvalid < StandardError; end
+end

--- a/lib/mini_api/model_responder.rb
+++ b/lib/mini_api/model_responder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'mini_api/serialization'
+require 'mini_api/case_transform'
 
 module MiniApi
   # class to handle json render of ActiveRecord::Base instances and ActiveModel::Model's
@@ -29,6 +30,8 @@ module MiniApi
       # This is for an problem with ActiveModelSerializer that adds an error
       # attribute when resource is an ActiveModel instance
       body[:data] = body[:data].except('errors') if body[:data]&.key?('errors')
+
+      body = CaseTransform.response_keys(body)
 
       @controller.render json: body, status: status_code
     end

--- a/lib/mini_api/relation_responder.rb
+++ b/lib/mini_api/relation_responder.rb
@@ -2,6 +2,7 @@
 
 require 'mini_api/exceptions/kaminari_not_installed'
 require 'mini_api/serialization'
+require 'mini_api/case_transform'
 
 module MiniApi
   class RelationResponder
@@ -15,6 +16,10 @@ module MiniApi
 
     def respond
       meta, collection = extract_meta_and_collection
+
+      meta = CaseTransform.response_keys(meta)
+
+      collection = transform_case(collection.as_json)
 
       @controller.render json: {
         success: @options[:success] || true,
@@ -38,6 +43,10 @@ module MiniApi
         },
         serialiable_body(collection)
       ]
+    end
+
+    def transform_case(collection)
+      collection.map { |item| CaseTransform.response_keys(item) }
     end
 
     def transform_resource_to_collection

--- a/test/mini_api/case_transform_test.rb
+++ b/test/mini_api/case_transform_test.rb
@@ -14,42 +14,30 @@ class CaseTransformTest < ActiveSupport::TestCase
   end
 
   test 'should transform keys to camelLower when informed' do
-    MiniApi::Config.transform_keys_to = :camel_lower
-
     hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
 
-    result = MiniApi::CaseTransform.transform(hash)
+    result = MiniApi::CaseTransform.transform(hash, :camel_lower)
 
     expected = { 'firstName' => 'Some random Name', 'address' => { 'addressNumber' => '10' } }
 
     assert_equal result, expected
-
-    MiniApi::Config.transform_keys_to = :snake_case
   end
 
   test 'should transform keys to CamelCase when informed' do
-    MiniApi::Config.transform_keys_to = :camel_case
-
     hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
 
-    result = MiniApi::CaseTransform.transform(hash)
+    result = MiniApi::CaseTransform.transform(hash, :camel_case)
 
     expected = { 'FirstName' => 'Some random Name', 'Address' => { 'AddressNumber' => '10' } }
 
     assert_equal result, expected
-
-    MiniApi::Config.transform_keys_to = :snake_case
   end
 
   test 'should raise an error if informed option is not valid' do
-    MiniApi::Config.transform_keys_to = :test
-
     hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
 
     assert_raises MiniApi::CaseTransformOptionInvalid do
-      MiniApi::CaseTransform.transform(hash)
+      MiniApi::CaseTransform.transform(hash, :test)
     end
-
-    MiniApi::Config.transform_keys_to = :snake_case
   end
 end

--- a/test/mini_api/case_transform_test.rb
+++ b/test/mini_api/case_transform_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CaseTransformTest < ActiveSupport::TestCase
+  test 'should transform keys to snake case if not configuration is informed' do
+    hash = { 'firstName' => 'Some random Name', 'address' => { 'addressNumber' => '10' } }
+
+    result = MiniApi::CaseTransform.transform(hash)
+
+    expected = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
+
+    assert_equal result, expected
+  end
+
+  test 'should transform keys to camelLower when informed' do
+    MiniApi::Config.transform_keys_to = :camel_lower
+
+    hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
+
+    result = MiniApi::CaseTransform.transform(hash)
+
+    expected = { 'firstName' => 'Some random Name', 'address' => { 'addressNumber' => '10' } }
+
+    assert_equal result, expected
+
+    MiniApi::Config.transform_keys_to = :snake_case
+  end
+
+  test 'should transform keys to CamelCase when informed' do
+    MiniApi::Config.transform_keys_to = :camel_case
+
+    hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
+
+    result = MiniApi::CaseTransform.transform(hash)
+
+    expected = { 'FirstName' => 'Some random Name', 'Address' => { 'AddressNumber' => '10' } }
+
+    assert_equal result, expected
+
+    MiniApi::Config.transform_keys_to = :snake_case
+  end
+
+  test 'should raise an error if informed option is not valid' do
+    MiniApi::Config.transform_keys_to = :test
+
+    hash = { 'first_name' => 'Some random Name', 'address' => { 'address_number' => '10' } }
+
+    assert_raises MiniApi::CaseTransformOptionInvalid do
+      MiniApi::CaseTransform.transform(hash)
+    end
+
+    MiniApi::Config.transform_keys_to = :snake_case
+  end
+end

--- a/test/mini_api/default_responder_test.rb
+++ b/test/mini_api/default_responder_test.rb
@@ -10,7 +10,7 @@ class DefaultController < ActionController::Base
   end
 
   def show
-    render_json({ code: 441 }, message: 'could not be resolved')
+    render_json({ code: 441, other_message: 42 }, message: 'could not be resolved')
   end
 end
 
@@ -65,7 +65,7 @@ class DefaultResponderTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
 
-    assert_equal({ 'code' => 441 }, response.parsed_body['data'])
+    assert_equal({ 'code' => 441, 'other_message' => 42 }, response.parsed_body['data'])
   end
 
   test 'should return custom message if informed' do
@@ -88,5 +88,15 @@ class DefaultResponderTest < ActionDispatch::IntegrationTest
     get '/custom_status'
 
     assert_response :not_found
+  end
+
+  test 'should response keys as camel lower when configure' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    get '/show'
+
+    assert_equal({ 'code' => 441, 'otherMessage' => 42 }, response.parsed_body['data'])
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
   end
 end

--- a/test/mini_api/model_responder/active_model_failure_operations_test.rb
+++ b/test/mini_api/model_responder/active_model_failure_operations_test.rb
@@ -55,4 +55,23 @@ class ActiveModelFailureOperationsTest < ModelResponderTest
 
     assert_equal response.parsed_body['errors'], errors
   end
+
+  test 'should return active model errors as camel lower when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    post '/create', params: { first_name: 'Dummy', last_name: 'Model' }
+
+    assert_response :unprocessable_entity
+
+    refute response.parsed_body['success']
+
+    errors = {
+      firstName: ['is invalid'],
+      lastName: ['is invalid']
+    }.stringify_keys
+
+    assert_equal response.parsed_body['errors'], errors
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
 end

--- a/test/mini_api/model_responder/active_model_success_operations_test.rb
+++ b/test/mini_api/model_responder/active_model_success_operations_test.rb
@@ -46,4 +46,23 @@ class ActiveModelSuccessOperationsTest < ModelResponderTest
 
     assert response.parsed_body['success']
   end
+
+  test 'should return model attributes as camel lower when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    get '/'
+
+    assert_response :ok
+
+    data = {
+      firstName: 'Dummy',
+      lastName: 'Model'
+    }.stringify_keys
+
+    assert_equal response.parsed_body['data'], data
+
+    assert response.parsed_body['success']
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
 end

--- a/test/mini_api/model_responder/failure_operations_test.rb
+++ b/test/mini_api/model_responder/failure_operations_test.rb
@@ -76,4 +76,19 @@ class FailureOperationsTest < ModelResponderTest
 
     assert_not response.parsed_body['success']
   end
+
+  test 'should active record errors with camel lower keys when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    post '/dummy', params: { first_name: '', last_name: '' }
+
+    errors = {
+      'firstName' => ["can't be blank"],
+      'lastName' => ["can't be blank"]
+    }
+
+    assert_equal response.parsed_body['errors'], errors
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
 end

--- a/test/mini_api/model_responder/success_operations_test.rb
+++ b/test/mini_api/model_responder/success_operations_test.rb
@@ -61,4 +61,16 @@ class SuccessOperationsTest < ModelResponderTest
 
     assert_empty response.parsed_body
   end
+
+  test 'should active record instance with camel lower keys when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    post '/dummy', params: { first_name: 'Dummy', last_name: 'Record' }
+
+    expected_keys = %w[id firstName lastName]
+
+    assert_equal response.parsed_body['data'].keys, expected_keys
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
 end

--- a/test/mini_api/relation_responder_test.rb
+++ b/test/mini_api/relation_responder_test.rb
@@ -128,4 +128,34 @@ class RelationResponder < ActionDispatch::IntegrationTest
 
     assert_equal 25, response.parsed_body['data'].size
   end
+
+  test 'should return keys as camel_lower when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    1.upto(25) { |n| DummyRecord.create(first_name: "Dummy #{n}", last_name: "Record #{n}") }
+
+    get '/dummies'
+
+    assert_response :ok
+
+    response.parsed_body['data'].each do |dummy|
+      assert_equal %w[id firstName lastName], dummy.keys
+    end
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
+
+  test 'should return metadata keys as camel_lower when configured' do
+    MiniApi::Config.transform_response_keys_to = :camel_lower
+
+    DummyRecord.create(first_name: 'Dummy', last_name: 'Record')
+
+    get '/dummies'
+
+    assert_response :ok
+
+    assert_equal %w[currentPage nextPage prevPage totalPages totalRecords], response.parsed_body['meta'].keys
+
+    MiniApi::Config.transform_response_keys_to = :snake_case
+  end
 end

--- a/test/mini_api_test.rb
+++ b/test/mini_api_test.rb
@@ -45,22 +45,22 @@ class MiniApiTest < ActionDispatch::IntegrationTest
   end
 
   test 'should transform keys to camelLower when configured' do
-    MiniApi::Config.transform_keys_to = :camel_lower
+    MiniApi::Config.transform_params_keys_to = :camel_lower
 
     get '/new', params: { 'first_name' => 'Dummy', 'last_name' => 'Model' }
 
     assert_response :ok
 
-    MiniApi::Config.transform_keys_to = :snake_case
+    MiniApi::Config.transform_params_keys_to = :snake_case
   end
 
   test 'should transform keys to CamelCase when informed' do
-    MiniApi::Config.transform_keys_to = :camel_case
+    MiniApi::Config.transform_params_keys_to = :camel_case
 
     get '/new', params: { 'first_name' => 'Dummy', 'last_name' => 'Model' }
 
     assert_response :ok
 
-    MiniApi::Config.transform_keys_to = :snake_case
+    MiniApi::Config.transform_params_keys_to = :snake_case
   end
 end

--- a/test/mini_api_test.rb
+++ b/test/mini_api_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DummyModel
+  include ActiveModel::Model
+
+  attr_accessor :first_name, :last_name
+end
+
+class MiniTestController < ActionController::Base
+  include MiniApi
+
+  def new
+    dummy = DummyModel.new(first_name: params[:first_name], last_name: params[:last_name])
+
+    render_json dummy
+  end
+
+  def camel_lower
+    dummy = DummyModel.new(first_name: params[:firstName], last_name: params[:firstName])
+
+    render_json dummy
+  end
+
+  def camel_case
+    dummy = DummyModel.new(first_name: params[:FirstName], last_name: params[:FirstName])
+
+    render_json dummy
+  end
+end
+
+class MiniApiTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.application.routes.draw do
+      get '/new', to: 'mini_test#new'
+      get '/camel_lower', to: 'mini_test#camel_lower'
+    end
+  end
+
+  test 'should transform params to snake case if no config was provided' do
+    get '/new', params: { 'firstName' => 'Dummy', 'lastName' => 'Model' }
+
+    assert_response :ok
+  end
+
+  test 'should transform keys to camelLower when configured' do
+    MiniApi::Config.transform_keys_to = :camel_lower
+
+    get '/new', params: { 'first_name' => 'Dummy', 'last_name' => 'Model' }
+
+    assert_response :ok
+
+    MiniApi::Config.transform_keys_to = :snake_case
+  end
+
+  test 'should transform keys to CamelCase when informed' do
+    MiniApi::Config.transform_keys_to = :camel_case
+
+    get '/new', params: { 'first_name' => 'Dummy', 'last_name' => 'Model' }
+
+    assert_response :ok
+
+    MiniApi::Config.transform_keys_to = :snake_case
+  end
+end


### PR DESCRIPTION
- feat: add module to transform hash keys
- feat: add a config module to permit configuration of transform keys
- feat: transform request parameters based on configuration
- feat: split configuration for transform params in two
- feat: add tranform keys to relation and model responder
- feat: add tranform keys to default responder
