### PR TITLE
feat: permit ModelResponder create a nested serializer to render errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A gem to standardize json responses in Rails applications, highly inspired on [R
 - [Usage](#usage)
   - [Respondering json](#respondering-json)
   - [Success and failure actions](#success-and-failure-actions)
+  - [Errors](#errors)
   - [Transform keys](#transform-keys)
 - [Overriding response](#overriding-response)
 - [Pagination](#pagination)
@@ -141,6 +142,40 @@ witht `status_code` 422
 The `message` key is different based on actions on informed model: create, update, and destroy
 
 You can respond any type of data, but ActiveRecord/ActiveModel::Model and ActiveRecord::Relation has a special treatment as shown above
+
+### Errors
+To show errors of a model, by default will use the `errors.messages` method, but `MiniApi` adds an ability to `active_model_serializers` to create a error serializer
+as a nested class in your serializer. Example:
+```ruby
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :first_name, :last_name
+
+  class Error < ActiveModel::Serializer
+    attributes :user
+
+    def user
+      {
+        first_name: object.errors[:first_name],
+        last_name: object.errors[:last_name],
+      }
+    end
+  end
+end
+```
+The response will be like:
+```json
+{
+  "success": false,
+  "errors": {
+    "user": {
+      "first_name": "can't be blank",
+      "last_name": "can't be blank"
+    }
+  },
+  "message": "User could not be created."
+}
+```
+You can create serializers for non `ActiveRecord` and add a nested `Error` class too
 
 ### Transform keys
 

--- a/lib/mini_api/model_responder.rb
+++ b/lib/mini_api/model_responder.rb
@@ -22,7 +22,7 @@ module MiniApi
 
       body =
         if resource_has_errors?
-          { errors: @resource.errors.messages }.merge(body)
+          errors.merge(body)
         else
           { data: serialiable_body(@resource).as_json }.merge(body)
         end
@@ -40,6 +40,14 @@ module MiniApi
 
     def resource_has_errors?
       !@resource.errors.empty?
+    end
+
+    def errors
+      error_serializer = get_error_serializer(@resource)
+
+      return { errors: @resource.errors.messages } unless error_serializer
+
+      { errors: error_serializer.new(@resource).as_json }
     end
 
     def status_code

--- a/lib/mini_api/serialization.rb
+++ b/lib/mini_api/serialization.rb
@@ -12,5 +12,11 @@ module MiniApi
 
       @controller.get_serializer(resource)
     end
+
+    def get_error_serializer(resource)
+      serializer_class = @controller.get_serializer(resource)
+
+      "#{serializer_class.serializer}::Error".safe_constantize
+    end
   end
 end

--- a/test/mini_api/model_responder/custom_error_serializer_test.rb
+++ b/test/mini_api/model_responder/custom_error_serializer_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'mini_api/model_responder_test'
+
+module CustomErrorSerializer
+  class DummyRecord < ActiveRecord::Base
+    validates :first_name, presence: true
+    validates :last_name, presence: true
+  end
+
+  class DummyRecordSerializer < ActiveModel::Serializer
+    attributes :first_name, :last_name
+
+    class Error < ActiveModel::Serializer
+      attributes :dummy
+
+      def dummy
+        {
+          'first_name' => object.errors[:first_name],
+          'last_name' => object.errors[:last_name]
+        }
+      end
+    end
+  end
+
+  class DummyRecordsController < ActionController::Base
+    include MiniApi
+
+    def create
+      dummy_params = { first_name: params[:first_name], last_name: params[:last_name] }
+
+      dummy_record = DummyRecord.new(dummy_params)
+
+      dummy_record.save
+
+      render_json dummy_record
+    end
+  end
+
+  class CustomErrorSerializerTest < ModelResponderTest
+    setup do
+      Rails.application.routes.draw do
+        namespace :custom_error_serializer do
+          post '/dummy', to: 'dummy_records#create'
+        end
+      end
+    end
+
+    test 'should use custom render error when defined' do
+      post '/custom_error_serializer/dummy'
+
+      assert_response :unprocessable_entity
+
+      errors = {
+        'dummy' => {
+          'first_name' => ["can't be blank"],
+          'last_name' => ["can't be blank"]
+        }
+      }
+
+      assert_equal response.parsed_body['errors'], errors
+
+      assert_equal 'Dummy record could not be created.', response.parsed_body['message']
+    end
+
+    test 'success should be false' do
+      post '/custom_error_serializer/dummy'
+
+      refute response.parsed_body['success']
+    end
+  end
+end


### PR DESCRIPTION
closes #17
