### PR TITLE
feat/support controller name on messages translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ By default support the actions: `create`, `update` and `delete`, but you can add
 You can add translation based on models, changing the `action` key for your model name. Example:
 `mini_api.messages.model_name.create.alert`. With this, is more easy personalize messages
 
+It is possible define a translation based on controller, useful if you use nested controlers. The path is:
+`min_api.messages.controller_name.action_name.alert`
+
 ### Transform keys
 
 It is possible to transform the keys of request and response. By default, will transform to `snake_case`, but the possible values are `snake_case`, `camel_lower` and `camel_case`

--- a/lib/mini_api/model_responder.rb
+++ b/lib/mini_api/model_responder.rb
@@ -2,11 +2,13 @@
 
 require 'mini_api/serialization'
 require 'mini_api/case_transform'
+require 'mini_api/translation/message'
 
 module MiniApi
   # class to handle json render of ActiveRecord::Base instances and ActiveModel::Model's
   class ModelResponder
     include Serialization
+    include Translation::Message
 
     def initialize(controller, resource, options = {})
       @controller = controller
@@ -17,7 +19,7 @@ module MiniApi
     def respond
       body = {
         success: resource_has_errors? == false,
-        message: @options[:message] || default_message
+        message: @options[:message] || message
       }
 
       body =
@@ -56,28 +58,6 @@ module MiniApi
       return :no_content if destroyed?
 
       :ok
-    end
-
-    def default_message
-      kind = resource_has_errors? ? 'alert' : 'notice'
-
-      model_path = "mini_api.messages.#{@resource.model_name.i18n_key}"
-
-      if I18n.exists? model_path
-        I18n.t(
-          kind,
-          scope: "#{model_path}.#{@controller.action_name}",
-          resource_name: @resource.class.model_name.human,
-          default: ''
-        )
-      else
-        I18n.t(
-          kind,
-          scope: [:mini_api, :messages, :actions, @controller.action_name],
-          resource_name: @resource.class.model_name.human,
-          default: ''
-        )
-      end
     end
 
     def previously_new_record?

--- a/lib/mini_api/translation/message.rb
+++ b/lib/mini_api/translation/message.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module MiniApi
+  module Translation
+    # Module to handle the +message+ key on json response.
+    # Will identify if model has errors or not and define the I18n path to +notice+, for model without errors
+    # and +alert+ for model with errors.
+    # There is three possible path for messages:
+    #
+    # The path based on model name
+    # mini_api:
+    #   messages:
+    #     model_name:
+    #       action_name:
+    #         notitce:
+    #         alert:
+    #
+    # The path based on controller name
+    # mini_api:
+    #   messages:
+    #     controller:
+    #       controller_name:
+    #         action_name:
+    #           notitce:
+    #           alert:
+    #
+    # And the last, is per action path:
+    # mini_api:
+    #   messages:
+    #     actions:
+    #       create:
+    #         notice: '%{resource_name} foi criado com sucesso.'
+    #         alert: '%{resource_name} não pôde ser criado.'
+
+    module Message
+      def message
+        kind = @resource.errors.empty? ? 'notice' : 'alert'
+
+        I18n.t(
+          kind,
+          scope: model_message_path || controller_message_path || default_message_path,
+          resource_name: @resource.class.model_name.human,
+          default: ''
+        )
+      end
+
+      private
+
+      def model_message_path
+        model_path = "mini_api.messages.#{@resource.model_name.i18n_key}.#{@controller.action_name}"
+
+        model_path if I18n.exists? model_path
+      end
+
+      def controller_message_path
+        controller_path =
+          "mini_api.messages.controller.#{@controller.controller_name}.#{@controller.action_name}"
+
+        controller_path if I18n.exists? controller_path
+      end
+
+      def default_message_path
+        ['mini_api', 'messages', 'actions', @controller.action_name].join('.')
+      end
+    end
+  end
+end

--- a/test/locales/en.yml
+++ b/test/locales/en.yml
@@ -22,6 +22,12 @@ en:
           notice: 'nested! was created!'
           alert: 'nested! something was wrong!'
 
+      controller:
+        messages:
+          create:
+            notice: 'message controller notice'
+            alert: 'message controller alert'
+
 
   activerecord:
     models:

--- a/test/mini_api/model_responder/custom_translation_message_test.rb
+++ b/test/mini_api/model_responder/custom_translation_message_test.rb
@@ -24,10 +24,25 @@ class DummyCustomTranslationsController < ActionController::Base
   end
 end
 
+class MessagesController < ActionController::Base
+  include MiniApi
+
+  def create
+    dummy_params = { first_name: params[:first_name], last_name: params[:last_name] }
+
+    dummy_record = DummyRecord.new(dummy_params)
+
+    dummy_record.save
+
+    render_json dummy_record
+  end
+end
+
 class CustomTranslationMessageTest < ModelResponderTest
   setup do
     Rails.application.routes.draw do
       post '/create', to: 'dummy_custom_translations#create'
+      post '/controller_messages/create', to: 'messages#create'
     end
   end
 
@@ -47,5 +62,15 @@ class CustomTranslationMessageTest < ModelResponderTest
     assert_response :unprocessable_entity
 
     assert_equal 'something was wrong!', response.parsed_body['message']
+  end
+
+  test 'should use controller translations when defined' do
+    post '/controller_messages/create', params: { first_name: 'Dummy', last_name: 'Record' }
+
+    assert_equal 'message controller notice', response.parsed_body['message']
+
+    post '/controller_messages/create', params: {}
+
+    assert_equal 'message controller alert', response.parsed_body['message']
   end
 end


### PR DESCRIPTION
- feat: create module to handle response messages and implement controller key translations
- feat: add tests to controller messages support
- docs: add documentation about controller translations

closes #26
