### PR TITLE
fix: use default as_json method when does not have defined a resource class

### DIFF
--- a/lib/mini_api/serialization.rb
+++ b/lib/mini_api/serialization.rb
@@ -6,7 +6,8 @@ module MiniApi
   module Serialization
     # This method search by serializer using the module parents of controller.
     # With this, is possible define serializers for the same resource
-    # in different controller scopes
+    # in different controller scopes.
+    # If the resource class does not have a resource, will be use the default `as_json` method
     def serialiable_body(resource)
       controller_scope = @controller.class.module_parents
 
@@ -24,12 +25,14 @@ module MiniApi
 
           break serializer_class if serializer_class
 
-          break DefaultResource if controller_scope.empty?
+          break if controller_scope.empty?
 
           controller_scope.shift
         end
 
-      serializer_class.new(resource)
+      return serializer_class.new(resource) if serializer_class
+
+      resource
     end
 
     # Search by the nested class +Error+ on serializer
@@ -40,11 +43,6 @@ module MiniApi
       return unless error_serializer
 
       "#{error_serializer.class}::Error".safe_constantize
-    end
-
-    # Empty serializer class for when resource does not have a custom class
-    class DefaultResource
-      include Alba::Resource
     end
   end
 end

--- a/test/mini_api/serialization_test.rb
+++ b/test/mini_api/serialization_test.rb
@@ -2,28 +2,6 @@
 
 require 'test_helper'
 
-class DummiesController < ActionController::Base
-  include MiniApi
-
-  def index
-    dummies = DummyRecord.all
-
-    render_json dummies
-  end
-
-  def show
-    dummy = DummyRecord.first
-
-    render_json dummy
-  end
-end
-
-class DummyRecordResource
-  include Alba::Resource
-
-  attributes :id, :first_name, :last_name
-end
-
 class SerializationTest < ActionDispatch::IntegrationTest
   setup do
     ActiveRecord::Base.connection.create_table :dummy_records do |t|
@@ -45,136 +23,186 @@ class SerializationTest < ActionDispatch::IntegrationTest
   end
 end
 
-class BasicControllerAndResource < SerializationTest
-  setup do
-    Rails.application.routes.draw do
-      get '/', to: 'dummies#index'
-      get '/show', to: 'dummies#show'
+module WithDefinedResource
+  class DummiesController < ActionController::Base
+    include MiniApi
+
+    def index
+      dummies = DummyRecord.all
+
+      render_json dummies
+    end
+
+    def show
+      dummy = DummyRecord.first
+
+      render_json dummy
     end
   end
 
-  test 'should use serializer when avaliable to render collections' do
-    get '/'
-
-    assert_response :ok
-
-    dummies = [
-      {
-        id: 1,
-        first_name: 'Dummy 1',
-        last_name: 'Record 1'
-      }.stringify_keys,
-      {
-        id: 2,
-        first_name: 'Dummy 2',
-        last_name: 'Record 2'
-      }.stringify_keys
-    ]
-
-    assert_equal dummies, response.parsed_body['data']
-  end
-
-  test 'should use serializer when avaliable to render single instances' do
-    get '/show'
-
-    assert_response :ok
-
-    dummy = {
-      id: 1,
-      first_name: 'Dummy 1',
-      last_name: 'Record 1'
-    }.stringify_keys
-
-    assert_equal dummy, response.parsed_body['data']
-  end
-end
-
-module Api
-  module V1
-    class DummiesController < ActionController::Base
-      include MiniApi
-
-      def index
-        dummies = DummyRecord.all
-
-        render_json dummies
-      end
-    end
-
-    class DummyRecordResource
-      include Alba::Resource
-
-      attributes :last_name
-    end
-
-    class NestedControllerAndResource < ::SerializationTest
-      setup do
-        Rails.application.routes.draw do
-          namespace :api do
-            namespace :v1 do
-              get '/dummies', to: 'dummies#index'
-            end
-          end
-        end
-      end
-
-      test 'should use nested serializer for nested controller' do
-        get '/api/v1/dummies'
-
-        assert_response :ok
-
-        data = [
-          { 'last_name' => DummyRecord.first.last_name },
-          { 'last_name' => DummyRecord.last.last_name }
-        ]
-
-        assert_equal response.parsed_body['data'], data
-      end
-    end
-  end
-end
-
-module Different
   class DummyRecordResource
     include Alba::Resource
 
-    attributes :first_name
+    attributes :id, :first_name, :last_name
   end
 
-  module Scope
-    class DummiesController < ActionController::Base
-      include MiniApi
-
-      def index
-        dummies = DummyRecord.all
-
-        render_json dummies
+  class BasicControllerAndResource < SerializationTest
+    setup do
+      Rails.application.routes.draw do
+        get '/', to: 'with_defined_resource/dummies#index'
+        get '/show', to: 'with_defined_resource/dummies#show'
       end
     end
 
-    class DifferentScope < SerializationTest
-      setup do
-        Rails.application.routes.draw do
-          namespace :different do
-            namespace :scope do
-              get '/dummies', to: 'dummies#index'
-            end
-          end
+    test 'should use serializer when avaliable to render collections' do
+      get '/'
+
+      assert_response :ok
+
+      dummies = [
+        {
+          id: 1,
+          first_name: 'Dummy 1',
+          last_name: 'Record 1'
+        }.stringify_keys,
+        {
+          id: 2,
+          first_name: 'Dummy 2',
+          last_name: 'Record 2'
+        }.stringify_keys
+      ]
+
+      assert_equal dummies, response.parsed_body['data']
+    end
+
+    test 'should use serializer when avaliable to render single instances' do
+      get '/show'
+
+      assert_response :ok
+
+      dummy = {
+        id: 1,
+        first_name: 'Dummy 1',
+        last_name: 'Record 1'
+      }.stringify_keys
+
+      assert_equal dummy, response.parsed_body['data']
+    end
+  end
+
+  module Api
+    module V1
+      class DummiesController < ActionController::Base
+        include MiniApi
+
+        def index
+          dummies = DummyRecord.all
+
+          render_json dummies
         end
       end
 
-      test 'should find resource when controller is in different module tree' do
-        get '/different/scope/dummies'
+      class DummyRecordResource
+        include Alba::Resource
 
-        assert_response :ok
-
-        data = [
-          { 'first_name' => DummyRecord.first.first_name },
-          { 'first_name' => DummyRecord.last.first_name }
-        ]
-
-        assert_equal response.parsed_body['data'], data
+        attributes :last_name
       end
+
+      class NestedControllerAndResource < SerializationTest
+        setup do
+          Rails.application.routes.draw do
+            get '/api/v1/dummies', to: 'with_defined_resource/api/v1/dummies#index'
+          end
+        end
+
+        test 'should use nested serializer for nested controller' do
+          get '/api/v1/dummies'
+
+          assert_response :ok
+
+          data = [
+            { 'last_name' => DummyRecord.first.last_name },
+            { 'last_name' => DummyRecord.last.last_name }
+          ]
+
+          assert_equal response.parsed_body['data'], data
+        end
+      end
+    end
+  end
+
+  module Different
+    class DummyRecordResource
+      include Alba::Resource
+
+      attributes :first_name
+    end
+
+    module Scope
+      class DummiesController < ActionController::Base
+        include MiniApi
+
+        def index
+          dummies = DummyRecord.all
+
+          render_json dummies
+        end
+      end
+
+      class DifferentScope < SerializationTest
+        setup do
+          Rails.application.routes.draw do
+            get '/dummies', to: 'with_defined_resource/different/scope/dummies#index'
+          end
+        end
+
+        test 'should find resource when controller is in different module tree' do
+          get '/dummies'
+
+          assert_response :ok
+
+          data = [
+            { 'first_name' => DummyRecord.first.first_name },
+            { 'first_name' => DummyRecord.last.first_name }
+          ]
+
+          assert_equal response.parsed_body['data'], data
+        end
+      end
+    end
+  end
+end
+
+module DefaultResourceRenderer
+  class DummiesController < ActionController::Base
+    include MiniApi
+
+    def show
+      dummy = DummyRecord.first
+
+      render_json dummy
+    end
+  end
+
+  class DefaultResourceRendererTest < SerializationTest
+    setup do
+      Rails.application.routes.draw do
+        get '/dummy', to: 'default_resource_renderer/dummies#show'
+      end
+    end
+
+    test 'should use DefaultResource class when does not have an defined resource' do
+      get '/dummy'
+
+      dummy = DummyRecord.first
+
+      expected_data = {
+        'id' => dummy.id,
+        'first_name' => dummy.first_name,
+        'last_name' => dummy.last_name
+      }
+
+      assert_equal response.parsed_body['data'], expected_data
     end
   end
 end


### PR DESCRIPTION
fix #33
